### PR TITLE
uiImInputText: Don't rely on magic null terminator

### DIFF
--- a/source/inui/widgets/input.d
+++ b/source/inui/widgets/input.d
@@ -143,7 +143,7 @@ bool uiImInputText(string wId, string label, float width, ref string buffer, ImG
             if (data.EventFlag == ImGuiInputTextFlags.CallbackResize) {
             
                 // Resize and pass buffer ptr in
-                (*udata.str).length = data.BufTextLen;
+                (*udata.str).length = data.BufTextLen + 1;
                 data.Buf = cast(char*)(*udata.str).ptr;
             }
             return 0;

--- a/source/inui/widgets/input.d
+++ b/source/inui/widgets/input.d
@@ -39,6 +39,8 @@ bool uiImInputText(string wId, float width, ref string buffer, ImGuiInputTextFla
         buffer = "";
     }
 
+    buffer ~= "\0";
+
     // Push ID
     igPushID(igGetID(wId.ptr, wId.ptr+wId.length));
     scope(exit) igPopID();
@@ -51,10 +53,10 @@ bool uiImInputText(string wId, float width, ref string buffer, ImGuiInputTextFla
     igPushItemWidth(width);
     scope(exit) igPopItemWidth();
 
-    if (igInputText(
+    bool res = igInputText(
         "###INPUT",
         cast(char*)buffer.ptr, 
-        buffer.length+1,
+        buffer.length,
         flags | ImGuiInputTextFlags.CallbackResize,
         cast(ImGuiInputTextCallback)(ImGuiInputTextCallbackData* data) {
             TextCallbackUserData* udata = cast(TextCallbackUserData*)data.UserData;
@@ -63,13 +65,17 @@ bool uiImInputText(string wId, float width, ref string buffer, ImGuiInputTextFla
             if (data.EventFlag == ImGuiInputTextFlags.CallbackResize) {
             
                 // Resize and pass buffer ptr in
-                (*udata.str).length = data.BufTextLen;
+                (*udata.str).length = data.BufTextLen + 1;
                 data.Buf = cast(char*)(*udata.str).ptr;
             }
             return 0;
         },
         &cb
-    )) {
+    );
+
+    buffer.length--;
+
+    if (res) {
         return true;
     }
 
@@ -105,6 +111,8 @@ bool uiImInputText(string wId, string label, float width, ref string buffer, ImG
         buffer = "";
     }
 
+    buffer ~= "\0";
+
     // Push ID
     igPushID(igGetID(wId.ptr, wId.ptr+wId.length));
     scope(exit) igPopID();
@@ -123,10 +131,10 @@ bool uiImInputText(string wId, string label, float width, ref string buffer, ImG
         igTextEx(label.ptr, label.ptr+label.length);
     }
 
-    if (igInputText(
+    bool res = igInputText(
         "###INPUT",
         cast(char*)buffer.ptr, 
-        buffer.length+1,
+        buffer.length,
         flags | ImGuiInputTextFlags.CallbackResize,
         cast(ImGuiInputTextCallback)(ImGuiInputTextCallbackData* data) {
             TextCallbackUserData* udata = cast(TextCallbackUserData*)data.UserData;
@@ -141,7 +149,11 @@ bool uiImInputText(string wId, string label, float width, ref string buffer, ImG
             return 0;
         },
         &cb
-    )) {
+    );
+
+    buffer.length--;
+
+    if (res) {
         return true;
     }
 


### PR DESCRIPTION
D strings are not null-terminated in memory, but `inui`'s text inputs at present assume an extra (presumably assumed 0) character when passing the buffers to Imgui (which expects null-terminated strings and for reading purposes ignores the passed buffer length)

That leads to this:
![image](https://user-images.githubusercontent.com/22304167/181994966-1ec83ca1-cc5d-4fc3-9a2c-f5ef9d2f42ba.png)

To prevent corruption and possible corruption side-effects, this patch concatenates a zero byte before the call and removes it afterwards.
