### PR TITLE
Expose window handle string

### DIFF
--- a/source/inui/core/window/appwin.d
+++ b/source/inui/core/window/appwin.d
@@ -379,6 +379,16 @@ public:
         uiImCleanupDialogs();
     }
 
+    string getWindowHandle() {
+        SDL_SysWMinfo info;
+        auto res = SDL_GetWindowWMInfo(window, &info);
+        if (info.subsystem == SDL_SYSWM_TYPE.SDL_SYSWM_X11) {
+            import std.conv : to;
+            return "x11:" ~ info.info.x11.window.to!string(16);
+        }
+        return "";
+    }
+
     /**
         Forces the window to be focused
     */


### PR DESCRIPTION
Exposes the window handle string for x11 systems, required to implement open-file dialog in inochi-session