### PR TITLE
Encapsulate linux specific code.

### DIFF
--- a/source/inui/core/window/appwin.d
+++ b/source/inui/core/window/appwin.d
@@ -380,11 +380,13 @@ public:
     }
 
     string getWindowHandle() {
-        SDL_SysWMinfo info;
-        auto res = SDL_GetWindowWMInfo(window, &info);
-        if (info.subsystem == SDL_SYSWM_TYPE.SDL_SYSWM_X11) {
-            import std.conv : to;
-            return "x11:" ~ info.info.x11.window.to!string(16);
+        version(linux) {
+            SDL_SysWMinfo info;
+            auto res = SDL_GetWindowWMInfo(window, &info);
+            if (info.subsystem == SDL_SYSWM_TYPE.SDL_SYSWM_X11) {
+                import std.conv : to;
+                return "x11:" ~ info.info.x11.window.to!string(16);
+            }
         }
         return "";
     }


### PR DESCRIPTION
I was made aware that the latest commit breaks the build on windows (and possibly mac).

```powershell
D:\...\inui\source\inui\core\window\appwin.d(421,38): Error: no property `x11` for `info.info` of type `bindbc.sdl.bind.sdlsyswm.SDL_SysWMinfo.info_`
C:\...\dub\packages\bindbc-sdl\1.1.3\bindbc-sdl\source\bindbc\sdl\bind\sdlsyswm.d(175,5):
        union `info_` defined here
Error C:\D\dmd2\windows\bin\dmd.exe failed with exit code 1.
```

Researching a bit I noticed that the WindowWMInfo info parameter structure is platform dependent, so I encapsulated this method in a version(linux) block.

This code was written to enable using portals to open files on the flatpak release.